### PR TITLE
suppress messages to use zoekt as grep

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -83,7 +83,9 @@ func main() {
 			log.Fatal(err)
 		}
 		defer f.Close()
-		log.Println("Displaying matches...")
+		if *verbose {
+			log.Println("Displaying matches...")
+		}
 		pprof.StartCPUProfile(f)
 		for i := 0; i < 10; i++ {
 			sres, err = searcher.Search(context.Background(), query, &sOpts)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -77,8 +77,8 @@ func (tl *throttledLoader) load(key string) {
 	tl.throttle <- struct{}{}
 	shard, err := loadShard(key)
 	<-tl.throttle
-	log.Printf("reloading: %s, err %v ", key, err)
 	if err != nil {
+		log.Printf("reloading: %s, err %v ", key, err)
 		return
 	}
 


### PR DESCRIPTION
This is useful to set grepprg=zoekt for Vim.