### PR TITLE
cmd/zoekt-index: check for errors while walking the dir

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -33,6 +33,10 @@ type fileAggregator struct {
 }
 
 func (a *fileAggregator) add(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
 	if info.IsDir() {
 		base := filepath.Base(path)
 		if _, ok := a.ignoreDirs[base]; ok {


### PR DESCRIPTION
calling `zoekt-index` with a directory that doesn't exist ends in a panic:

    $ zoekt-index /t/a/a                                                     
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6e47c6]
    goroutine 8 [running]:
    main.(*fileAggregator).add(0xc4201143a0, 0x7ffce775677c, 0x6, 0x0, 0x0, 0x94f880, 0xc4201424b0, 0xc4201424b0, 0xc4201445b0)
        /home/vincent/dev/go/src/github.com/google/zoekt/cmd/zoekt-index/main.go:36 +0x26
    main.(*fileAggregator).(main.add)-fm(0x7ffce775677c, 0x6, 0x0, 0x0, 0x94f880, 0xc4201424b0, 0x6, 0xc42003dfa0)
        /home/vincent/dev/go/src/github.com/google/zoekt/cmd/zoekt-index/main.go:117 +0x69
    path/filepath.Walk(0x7ffce775677c, 0x6, 0xc42003df90, 0x0, 0x0)
        /usr/local/go/src/path/filepath/path.go:401 +0x76
    main.indexArg.func1(0x7ffce775677c, 0x6, 0xc4201143a0, 0xc42006e240)
        /home/vincent/dev/go/src/github.com/google/zoekt/cmd/zoekt-index/main.go:117 +0x59
    created by main.indexArg
        /home/vincent/dev/go/src/github.com/google/zoekt/cmd/zoekt-index/main.go:116 +0x1b5

we can fix this by checking the error in the walk function and now it ends with the error logged:

    $ zoekt-index /t/a/a                                                                                                                        
    2018/01/26 16:19:34 lstat /t/a/a: no such file or directory

This change has the additional effect that any error in a subdirectory or file will exit the application, I don't know if that's reasonable for you.