### PR TITLE
Add an -r option to zoekt to display the repository

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -29,10 +29,14 @@ import (
 	"github.com/google/zoekt/shards"
 )
 
-func displayMatches(files []zoekt.FileMatch, pat string) {
+func displayMatches(files []zoekt.FileMatch, pat string, withRepo bool) {
 	for _, f := range files {
 		for _, m := range f.LineMatches {
-			fmt.Printf("%s:%d:%s\n", f.FileName, m.LineNumber, m.Line)
+			if withRepo {
+				fmt.Printf("%s/%s:%d:%s\n", f.Repository, f.FileName, m.LineNumber, m.Line)
+			} else {
+				fmt.Printf("%s:%d:%s\n", f.FileName, m.LineNumber, m.Line)
+			}
 		}
 	}
 }
@@ -63,6 +67,7 @@ func main() {
 	cpuProfile := flag.String("cpu_profile", "", "write cpu profile to `file`")
 	profileTime := flag.Duration("profile_time", time.Second, "run this long to gather stats.")
 	verbose := flag.Bool("v", false, "print some background data")
+	withRepo := flag.Bool("r", false, "print the repo before the file name")
 
 	flag.Usage = func() {
 		name := os.Args[0]
@@ -129,7 +134,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	displayMatches(sres.Files, pat)
+	displayMatches(sres.Files, pat, *withRepo)
 	if *verbose {
 		log.Printf("stats: %#v", sres.Stats)
 	}


### PR DESCRIPTION
This is useful when indexing multiple repositories. 
The web UI already shows the repository, this matches that functionality for the command line.