### PR TITLE
Add missing installing instruction for automaxprocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Downloading:
 
 Indexing:
 
+    go get -u go.uber.org/automaxprocs
     go install github.com/google/zoekt/cmd/zoekt-index
     $GOPATH/bin/zoekt-index .
 


### PR DESCRIPTION
Following the instructions led to
```
go install github.com/google/zoekt/cmd/zoekt-index
/home/ngirard/go/src/github.com/google/zoekt/cmd/zoekt-index/main.go:30:2: cannot find package "go.uber.org/automaxprocs/maxprocs" in any of:
        /usr/lib/go-1.10/src/go.uber.org/automaxprocs/maxprocs (from $GOROOT)
        /home/ngirard/go/src/go.uber.org/automaxprocs/maxprocs (from $GOPATH)
```