### PR TITLE
Set up precise code intelligence with Sourcegraph

### DIFF
--- a/.github/workflows/lsif.yaml
+++ b/.github/workflows/lsif.yaml
@@ -1,0 +1,16 @@
+name: LSIF
+on:
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate LSIF Data
+        uses: sourcegraph/lsif-go-action@master
+        with:
+          verbose: "true"
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
+        with:
+          public_repo_github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}


### PR DESCRIPTION
Sourcegraph recently added support for precise code intelligence using [LSIF](https://docs.sourcegraph.com/user/code_intelligence/lsif), and we're looking for open source projects (such as Zoekt) to try it out!

With LSIF-based code intelligence and the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension), you'll get hover tooltips on GitHub code views and PRs:

![image](https://user-images.githubusercontent.com/1387653/69389938-bf234000-0c8a-11ea-868c-144c2a9f42ae.png)

You can try it out on my fork before merging https://sourcegraph.com/github.com/chrismwendt/zoekt/-/blob/cmd/zoekt/main.go#L34:23

Without LSIF, you'll only see the default code intelligence, which is fuzzy and based on ctags + text search (circuitously powered by Zoekt!).

All you need to do is:

- [ ] Generate a GitHub access token with [`public_repo` scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) at https://github.com/settings/tokens
- [ ] Create a new secret https://github.com/google/zoekt/settings/secrets called `PUBLIC_REPO_GITHUB_TOKEN` with that token
- [ ] Merge this PR

Every commit thereafter will trigger the LSIF action to generate and upload LSIF data for this repository to Sourcegraph.com. Anyone visiting https://sourcegraph.com/github.com/google/zoekt or viewing this repository with the Sourcegraph browser extension will then see precise code intelligence.