### PR TITLE
improve performance for content searches

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -176,7 +176,8 @@ func (q *Not) String() string {
 
 // And is matched when all its children are.
 type And struct {
-	Children []Q
+	Children  []Q
+	NoNewline bool
 }
 
 func (q *And) String() string {
@@ -244,7 +245,7 @@ func flatten(q Q) (Q, bool) {
 			return s.Children[0], true
 		}
 		flatChildren, changed := flattenAndOr(s.Children, s)
-		return &And{flatChildren}, changed
+		return &And{flatChildren, s.NoNewline}, changed
 	case *Or:
 		if len(s.Children) == 1 {
 			return s.Children[0], true
@@ -276,7 +277,7 @@ func invertConst(q Q) Q {
 }
 
 func evalAndOrConstants(q Q, children []Q) Q {
-	_, isAnd := q.(*And)
+	oldAnd, isAnd := q.(*And)
 
 	children = mapQueryList(children, evalConstants)
 
@@ -296,7 +297,7 @@ func evalAndOrConstants(q Q, children []Q) Q {
 		return &Const{isAnd}
 	}
 	if isAnd {
-		return &And{newCH}
+		return &And{newCH, oldAnd.NoNewline}
 	}
 	return &Or{newCH}
 }
@@ -346,7 +347,7 @@ func Simplify(q Q) Q {
 func Map(q Q, f func(q Q) Q) Q {
 	switch s := q.(type) {
 	case *And:
-		q = &And{Children: mapQueryList(s.Children, f)}
+		q = &And{Children: mapQueryList(s.Children, f), NoNewline: s.NoNewline}
 	case *Or:
 		q = &Or{Children: mapQueryList(s.Children, f)}
 	case *Not:

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -27,7 +27,7 @@ func TestQueryString(t *testing.T) {
 		&And{[]Q{
 			&Substring{Pattern: "hoi"},
 			&Not{&Substring{Pattern: "hai"}},
-		}}}}
+		}, true}}}
 	got := q.String()
 	want := `(or (and substr:"hoi" (not substr:"hai")))`
 


### PR DESCRIPTION
For content searches trying to match multiple terms on the same line, we check
whether the matches of the individual terms intersect before calling the
regex engine. If they don't intersect, we skip the document.

This optimization is useful whenever terms of the query appear often in
the same document but rarely on the same line.